### PR TITLE
docs: em-dash sweep across source comments

### DIFF
--- a/src/transforms/params.ts
+++ b/src/transforms/params.ts
@@ -80,7 +80,7 @@ function parseParamNode(node: SyntaxNode): FunctionParam | null {
     }
 
     default:
-      // Unknown parameter form — extract name from text
+      // Unknown parameter form: extract name from text
       return {
         name: node.text.split(":")[0]?.split("=")[0]?.trim().replace(/^\.\.\.|[?]$/g, "") ?? node.text,
         optional: node.text.includes("?") || node.text.includes("="),

--- a/tests/grammar_test.ts
+++ b/tests/grammar_test.ts
@@ -23,7 +23,7 @@ import {
 import "tree-sitter-typescript";
 
 // =============================================================================
-// Setup — shared parser instance across tests
+// Setup: shared parser instance across tests
 // =============================================================================
 
 let parser: Parser;
@@ -57,7 +57,7 @@ async function query(querySource: string, source: string) {
 }
 
 // =============================================================================
-// Export Extraction — the critical area where async/abstract bugs lived
+// Export Extraction: the critical area where async/abstract bugs lived
 // =============================================================================
 
 Deno.test("exports - export function extracts function name", async () => {
@@ -523,7 +523,7 @@ interface Repository<T> {
 });
 
 // =============================================================================
-// Query Syntax Validation — queries compile without error
+// Query Syntax Validation: queries compile without error
 // =============================================================================
 
 Deno.test("queries - function query compiles and produces matches", async () => {
@@ -563,7 +563,7 @@ Deno.test("queries - type query compiles and produces matches", async () => {
 
 Deno.test("queries - string query compiles", async () => {
   assertExists(typescript.queries.strings, "Should have string query");
-  // Just verify it compiles — run against a file with strings
+  // Just verify it compiles. Run against a file with strings
   const matches = await query(
     typescript.queries.strings!,
     `const msg = "hello world";`,
@@ -582,7 +582,7 @@ Deno.test("queries - docComment query compiles", async () => {
 });
 
 // =============================================================================
-// isExported Transform — verifies export detection via tree walking
+// isExported Transform: verifies export detection via tree walking
 // =============================================================================
 
 Deno.test("isExported - exported function detected", async () => {
@@ -612,7 +612,7 @@ const internal = () => { return "nope"; };
 });
 
 // =============================================================================
-// Full Integration — realistic file extraction
+// Full Integration: realistic file extraction
 // =============================================================================
 
 Deno.test("integration - realistic TypeScript module extraction", async () => {
@@ -656,7 +656,7 @@ export enum LogLevel {
 
   const data = await extract(source, "src/server.ts");
 
-  // Exports — verify all expected exports, no keyword leakage
+  // Exports: verify all expected exports, no keyword leakage
   const exportNames = data.exports.map((e) => e.name);
   for (const expected of [
     "AppConfig",


### PR DESCRIPTION
## Summary

Mechanical em-dash sweep across `.ts` source comments. Eight occurrences
across two files:

- `src/transforms/params.ts:83` (one inline aside)
- `tests/grammar_test.ts` (seven banner / inline comments)

Seven sites use `:` (colon) since each em-dash served as a label-to-
explanation bridge; one site (`tests/grammar_test.ts:566`) uses `.`
(period) since the em-dash there joined two independent clauses where
period is the right mark.

The audit also flagged the README skeleton not matching the workspace
canonical 5-badge format and a missing `description`/`license` in
`deno.json`. Both deferred: substantive content rewrite is out of
scope for a mechanical sweep, and no sibling deno-using repo currently
sets those fields.

## Test plan

- [x] `rg -nF $'\xe2\x80\x94'` clean across the repo
- [x] No information dropped (each comment retains its label + scope text)
- [x] No production code paths or test assertions affected (comment-only diff)