### PR TITLE
chore: 0.3.0-alpha.1, so dependents can resolve it

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiisi/viola-grammar-ts",
-  "version": "0.3.0",
+  "version": "0.3.0-alpha.1",
   "description": "TypeScript grammar package for the Viola convention linter.",
   "exports": {
     ".": "./mod.ts"
@@ -18,9 +18,9 @@
     ]
   },
   "imports": {
-    "@hiisi/viola": "jsr:@hiisi/viola@^0.3.0",
-    "@hiisi/viola/grammars": "jsr:@hiisi/viola@^0.3.0/grammars",
-    "@hiisi/viola/data": "jsr:@hiisi/viola@^0.3.0/data",
+    "@hiisi/viola": "jsr:@hiisi/viola@0.3.0-alpha.2",
+    "@hiisi/viola/grammars": "jsr:@hiisi/viola@0.3.0-alpha.2/grammars",
+    "@hiisi/viola/data": "jsr:@hiisi/viola@0.3.0-alpha.2/data",
     "@std/assert": "jsr:@std/assert@^1",
     "web-tree-sitter": "npm:web-tree-sitter@0.22.6",
     "tree-sitter-typescript": "npm:tree-sitter-typescript@0.23.2"


### PR DESCRIPTION
Nothing in the set is published, so every dependency between these packages resolves through `links` at sibling paths on one machine. A prerelease fixes that without claiming the thing is ready, and a caret skips it so nobody outside lands on it by accident.

## Sanity

Version bump only.