### PR TITLE
fix: a re-export is an import, and the grammar did not say so

### DIFF
--- a/src/queries/imports.ts
+++ b/src/queries/imports.ts
@@ -55,4 +55,21 @@ export const importQueries = `
 ; Side-effect imports
 (import_statement
   source: (string) @import.from) @import
+
+; Re-exports, which are imports for every purpose a lint cares about.
+; \`export { thing } from "./mod.ts"\` names a symbol and pulls it from another
+; module, and a barrel that re-exports its package's surface is the strongest
+; evidence a symbol is public. Without this the orphaned-code lint reported
+; every re-exported symbol as never imported, which is every public symbol in
+; a package built around a \`mod.ts\`.
+(export_statement
+  (export_clause
+    (export_specifier
+      name: (identifier) @import.name
+      alias: (identifier)? @import.alias))
+  source: (string) @import.from) @import
+
+; \`export * from "./mod.ts"\`, which names no symbol but still uses the module.
+(export_statement
+  source: (string) @import.from) @import
 `;

--- a/src/transforms/imports.ts
+++ b/src/transforms/imports.ts
@@ -32,6 +32,31 @@ export function parseImport(
   const isTypeOnly = captures.has("import.type_only")
     || node.children.some(c => c.type === "type");
 
+  // A re-export is an import for every purpose a lint cares about.
+  //
+  // `export { thing } from "./mod.ts"` names a symbol and pulls it from another
+  // module, which is exactly what an import does, and a barrel re-exporting a
+  // package's surface is the strongest evidence a symbol is public. Everything
+  // below reads `import_clause` and `named_imports`, which exist only under an
+  // `import_statement`, so an `export_statement` fell through to the default
+  // branch and produced a single import named "default".
+  //
+  // The visible symptom was the orphaned-code lint reporting every re-exported
+  // symbol as never imported, which in a package built around a `mod.ts` is
+  // every public symbol it has.
+  if (node.type === "export_statement") {
+    const clause = node.children.find((c) => c.type === "export_clause");
+    const specifiers = clause?.namedChildren.filter((c) => c.type === "export_specifier") ?? [];
+    const named = specifiers
+      .map((spec) => spec.childForFieldName("name")?.text)
+      .filter((name): name is string => name !== undefined && name.length > 0);
+
+    // `export * from "..."` names nothing but still uses the module.
+    return named.length > 0
+      ? named.map((name) => ({ name, from, location, isTypeOnly, isNamespace: false }))
+      : { name: "*", from, location, isTypeOnly, isNamespace: true };
+  }
+
   // Check for namespace import: import * as name from "mod"
   // The query captures the identifier as @import.name, so also check the AST
   // for a namespace_import node inside import_clause.


### PR DESCRIPTION
`export { thing } from "./mod.ts"` names a symbol and pulls it from another module, which is what an import does. The import query matched only `import_statement`, so re-exports never reached `file.imports`, and `parseImport` read `import_clause` and `named_imports`, which exist only under an import statement.

This matters most to the orphaned-code lint, whose `reexportCountsAsUsage` defaults to true and had nothing to act on. A package built around a barrel `mod.ts` re-exports its whole public surface through exactly this syntax.

## Sanity

`deno check` clean. Honest limit: this was written against a gate run that turned out to be executing the published grammar rather than this one, because per-package `links` are ignored outside a workspace root. So the fix is correct on its own terms and its effect on the orphan count is still unmeasured.