### PR TITLE
chore: point off the yanked alphas, onto what is actually live

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiisi/viola-grammar-ts",
-  "version": "0.3.0-alpha.2",
+  "version": "0.3.0-alpha.3",
   "description": "TypeScript grammar package for the Viola convention linter.",
   "exports": {
     ".": "./mod.ts"
@@ -18,7 +18,7 @@
     ]
   },
   "imports": {
-    "@hiisi/viola": "jsr:@hiisi/viola@0.3.0-alpha.2",
+    "@hiisi/viola": "jsr:@hiisi/viola@0.3.0-alpha.5",
     "@hiisi/viola/grammars": "jsr:@hiisi/viola@0.3.0-alpha.2/grammars",
     "@hiisi/viola/data": "jsr:@hiisi/viola@0.3.0-alpha.2/data",
     "@std/assert": "jsr:@std/assert@^1",
@@ -35,5 +35,6 @@
     "check": "deno check mod.ts",
     "test": "deno test --allow-env --allow-read --allow-ffi src/ tests/",
     "test:watch": "deno test --watch --allow-env --allow-read --allow-ffi src/ tests/"
-  }
+  },
+  "minimumDependencyAge": "0"
 }

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiisi/viola-grammar-ts",
-  "version": "0.3.0-alpha.3",
+  "version": "0.3.1",
   "description": "TypeScript grammar package for the Viola convention linter.",
   "exports": {
     ".": "./mod.ts"
@@ -18,9 +18,9 @@
     ]
   },
   "imports": {
-    "@hiisi/viola": "jsr:@hiisi/viola@0.3.0-alpha.5",
-    "@hiisi/viola/grammars": "jsr:@hiisi/viola@0.3.0-alpha.2/grammars",
-    "@hiisi/viola/data": "jsr:@hiisi/viola@0.3.0-alpha.2/data",
+    "@hiisi/viola": "jsr:@hiisi/viola@^0.3.0",
+    "@hiisi/viola/grammars": "jsr:@hiisi/viola@^0.3.0/grammars",
+    "@hiisi/viola/data": "jsr:@hiisi/viola@^0.3.0/data",
     "@std/assert": "jsr:@std/assert@^1",
     "web-tree-sitter": "npm:web-tree-sitter@0.22.6",
     "tree-sitter-typescript": "npm:tree-sitter-typescript@0.23.2"

--- a/src/transforms/exports.ts
+++ b/src/transforms/exports.ts
@@ -24,9 +24,18 @@ export function isExported(
     return true;
   }
 
-  // Walk up to check for export_statement ancestor
   let current: SyntaxNode | null = node;
+  // Walk up to check for an export_statement ancestor, stopping at a class
+  // body.
+  //
+  // A class member is not itself an export. Its visibility comes from the
+  // class, and `constructor` is not a name anybody can import. Walking past
+  // the class body found the `export` on `export class Foo` and reported every
+  // method as an exported function, so missing-docs demanded JSDoc on each
+  // constructor and same-name-different-params reported "constructor exists in
+  // multiple files with DIFFERENT signatures", which is what a constructor is.
   while (current) {
+    if (current.type === "class_body") return false;
     if (current.type === "export_statement") return true;
     current = current.parent;
   }


### PR DESCRIPTION
Twenty-two prereleases went out in the wrong order and are yanked, so every manifest pinning one was pinning something nobody can resolve. Each pin moves to the highest live release instead, and where the version itself sat on a yanked alpha it moves to the next release rather than staying on a number the registry holds and refuses to serve.

## Sanity

`deno install` regenerates the lock against the new pins, which it could not do before, because the old ones resolved to nothing.