### PR TITLE
feat: the gate, which this package does not yet pass

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# The gate. A commit that does not pass it does not happen.
+#
+# Deliberately harsher than the code was when this landed: every finding a
+# linter is at all sure of is an error, and tests are held to the same bar as
+# source. If this is in your way, the answer is the finding rather than the
+# hook.
+#
+# `--no-verify` exists and using it is a decision to put something in the
+# history that the gate refused.
+set -euo pipefail
+
+echo "gate: type check"
+deno check mod.ts
+
+echo "gate: tests"
+deno task test
+
+echo "gate: conventions"
+deno task lint
+
+echo "gate: passed"

--- a/deno.json
+++ b/deno.json
@@ -23,7 +23,8 @@
     "@hiisi/viola/data": "jsr:@hiisi/viola@^0.3.0/data",
     "@std/assert": "jsr:@std/assert@^1",
     "web-tree-sitter": "npm:web-tree-sitter@0.22.6",
-    "tree-sitter-typescript": "npm:tree-sitter-typescript@0.23.2"
+    "tree-sitter-typescript": "npm:tree-sitter-typescript@0.23.2",
+    "@hiisi/viola-default-lints": "jsr:@hiisi/viola-default-lints@^0.3.1"
   },
   "compilerOptions": {
     "strict": true,
@@ -34,7 +35,8 @@
   "tasks": {
     "check": "deno check mod.ts",
     "test": "deno test --allow-env --allow-read --allow-ffi src/ tests/",
-    "test:watch": "deno test --watch --allow-env --allow-read --allow-ffi src/ tests/"
+    "test:watch": "deno test --watch --allow-env --allow-read --allow-ffi src/ tests/",
+    "lint": "deno run -A --min-dep-age=0 jsr:@hiisi/viola-cli@^0.3.1 --project . --include src,mod.ts"
   },
-  "minimumDependencyAge": "0"
+  "minimumDependencyAge": 0
 }

--- a/viola.config.ts
+++ b/viola.config.ts
@@ -1,0 +1,28 @@
+/**
+ * What this package has to be true of before anything may be committed.
+ *
+ * Deliberately harsher than the code currently is. A lint set tuned to what
+ * already passes measures nothing, and the point of putting it here is that it
+ * refuses work rather than describes it.
+ *
+ * @module
+ */
+
+import defaultLints from "@hiisi/viola-default-lints";
+import typescript from "@hiisi/viola-grammar-ts";
+import { report, viola, when } from "@hiisi/viola";
+
+export default viola()
+  .use(defaultLints)
+  // the grammar is what turns a file into something a lint can ask questions of
+  .add(typescript).as("typescript")
+  // anything a linter is at all sure about is a failure. a warning is a
+  // finding nobody acts on, and a gate that warns is not a gate.
+  .rule(report.error, when.confidence.atLeast(50))
+  // tests are held to the same bar as source. a fixture that drifts is how a
+  // suite stops measuring the thing it names.
+  .rule(report.error, when.in("tests/**/*.ts"))
+  // fixtures that are supposed to be wrong are the one exception, since being
+  // wrong is their entire job.
+  .rule(report.off, when.in("tests/compile_fail/**"))
+  .rule(report.off, when.in("**/fixtures/**"));


### PR DESCRIPTION
viola runs on this package now, harsher than the code currently is. A lint set tuned to what already passes measures nothing.

Every finding a linter is at all sure of is an error, tests are held to the same bar as source, and fixtures that are meant to be wrong are the one exception. `.githooks/pre-commit` runs type check, tests and conventions, and a commit that fails it does not happen.

`minimumDependencyAge` is 0 because the estate self-hosts its linter and every version of it published today. That policy is aimed at a stranger's dependency rather than the package next door, and it comes out once the estate has aged.

## Sanity

This package does not pass yet, and that is the point. The gate lands ahead of the work it demands so the findings are visible rather than theoretical.