### PR TITLE
fix: the gate was measuring a third of the tree at half confidence

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -36,7 +36,7 @@
     "check": "deno check mod.ts",
     "test": "deno test --allow-env --allow-read --allow-ffi src/ tests/",
     "test:watch": "deno test --watch --allow-env --allow-read --allow-ffi src/ tests/",
-    "lint": "deno run -A --min-dep-age=0 jsr:@hiisi/viola-cli@^0.3.1 --project . --include src,mod.ts"
+    "lint": "deno run -A --min-dep-age=0 jsr:@hiisi/viola-cli@^0.3.1 --project . --include ."
   },
   "minimumDependencyAge": 0
 }

--- a/viola.config.ts
+++ b/viola.config.ts
@@ -18,7 +18,7 @@ export default viola()
   .add(typescript).as("typescript")
   // anything a linter is at all sure about is a failure. a warning is a
   // finding nobody acts on, and a gate that warns is not a gate.
-  .rule(report.error, when.confidence.atLeast(50))
+  .rule(report.error, when.confidence.atLeast(1))
   // tests are held to the same bar as source. a fixture that drifts is how a
   // suite stops measuring the thing it names.
   .rule(report.error, when.in("tests/**/*.ts"))


### PR DESCRIPTION
`--include src,mod.ts` scanned two thirds of the tree, so the config's own rule that tests are errors was never shown a test. The confidence floor was 50, so anything a linter was less than half sure of passed silently. The whole tree now, at a floor of 1.