### PR TITLE
fix: a template literal was captured twice, so every one read as a duplicate

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiisi/viola-grammar-ts",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "TypeScript grammar package for the Viola convention linter.",
   "exports": {
     ".": "./mod.ts"

--- a/src/queries/strings.ts
+++ b/src/queries/strings.ts
@@ -26,8 +26,13 @@ export const stringQueries = `
 (string
   (string_fragment)? @string.value) @string
 
-; Template literals
-(template_string) @string.value @string.template
+; Template literals.
+;
+; The node is captured for structure and its fragment for the value, and only
+; the fragment carries @string.value. Capturing both as the value matched the
+; same template twice, so every template literal in a codebase was reported as
+; appearing twice as often as it does, at the same line number.
+(template_string) @string.template
 
 ; Raw template string content
 (template_string

--- a/tests/grammar_test.ts
+++ b/tests/grammar_test.ts
@@ -563,13 +563,41 @@ Deno.test("queries - type query compiles and produces matches", async () => {
 
 Deno.test("queries - string query compiles", async () => {
   assertExists(typescript.queries.strings, "Should have string query");
-  // Just verify it compiles. Run against a file with strings
   const matches = await query(
     typescript.queries.strings!,
     `const msg = "hello world";`,
   );
-  // String query should at least compile without error
-  assertEquals(matches.length >= 0, true);
+  // `>= 0` was the old assertion here and it cannot fail, so it measured
+  // nothing. A quoted string is one value.
+  assertEquals(valuesOf(matches), ["hello world"]);
+});
+
+/** Every `@string.value` capture, in source order. */
+function valuesOf(matches: Awaited<ReturnType<typeof query>>): string[] {
+  return matches
+    .map((m) => m.get("string.value")?.text)
+    .filter((t): t is string => t !== undefined);
+}
+
+Deno.test("queries - a template literal is one string, not two", async () => {
+  // Two of the three patterns used to capture `@string.value` on the same
+  // template: once for the whole node and once for its fragment. Every
+  // template literal in a codebase was therefore reported as appearing twice
+  // as often as it does, at one and the same line, and `duplicate-strings`
+  // raised a duplicate for a string written exactly once.
+  const matches = await query(
+    typescript.queries.strings!,
+    "const msg = `only once`;",
+  );
+  assertEquals(valuesOf(matches), ["only once"]);
+});
+
+Deno.test("queries - an interpolated template yields its fragments once each", async () => {
+  const matches = await query(
+    typescript.queries.strings!,
+    "const msg = `before ${x} after`;",
+  );
+  assertEquals(valuesOf(matches), ["before ", " after"]);
 });
 
 Deno.test("queries - docComment query compiles", async () => {


### PR DESCRIPTION
Two of the three string patterns captured `@string.value` on the same node, once for the whole `template_string` and once for its `string_fragment`. So every template literal in every codebase this grammar reads was counted twice, at one and the same line.

What that did downstream: `duplicate-strings` raised a duplicate for a string written exactly once. `flash-freeze` was told `"Use freeze() or frozenCopy() to create immutable data."` appeared twice, and both reported locations were `src/validation.ts:198`. It appears once in the whole package.

## Sanity

The test that was there asserted `matches.length >= 0`, which cannot fail and measured nothing. It now asserts the values. Two more laws beside it: a template is one string, and an interpolated one yields its fragments once each.

Controlled both ways. Putting the old pattern back turns the new test red; restoring it turns it green. 54 pass.