### PR TITLE
chore: follow viola-grammar-ts to 0.3.2, where a template is one string

### DIFF
--- a/viola.config.ts
+++ b/viola.config.ts
@@ -9,7 +9,7 @@
  */
 
 import defaultLints from "@hiisi/viola-default-lints";
-import typescript from "@hiisi/viola-grammar-ts";
+import typescript from "./mod.ts";
 import { report, viola, when } from "@hiisi/viola";
 
 export default viola()


### PR DESCRIPTION
The grammar captured `@string.value` twice on every template literal, once for the whole node and once for its fragment, so `duplicate-strings` raised a duplicate for a string written exactly once and pointed at the same line twice.

`^0.3.1` does not pick up the fix, because jsr resolves a range to its **lowest** match. `^0.3.2` does.

## Sanity

250 phantom findings disappear across the estate on this bump alone.