### PR TITLE
chore: bump to 0.4.0 and follow the lint pack

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -18,9 +18,9 @@
     ]
   },
   "imports": {
-    "@hiisi/viola": "jsr:@hiisi/viola@^0.3.0",
-    "@hiisi/viola/grammars": "jsr:@hiisi/viola@^0.3.0/grammars",
-    "@hiisi/viola/data": "jsr:@hiisi/viola@^0.3.0/data",
+    "@hiisi/viola": "jsr:@hiisi/viola@^0.4.0",
+    "@hiisi/viola/grammars": "jsr:@hiisi/viola@^0.4.0/grammars",
+    "@hiisi/viola/data": "jsr:@hiisi/viola@^0.4.0/data",
     "@std/assert": "jsr:@std/assert@^1",
     "web-tree-sitter": "npm:web-tree-sitter@0.22.6",
     "tree-sitter-typescript": "npm:tree-sitter-typescript@0.23.2",

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiisi/viola-grammar-ts",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "TypeScript grammar package for the Viola convention linter.",
   "exports": {
     ".": "./mod.ts"
@@ -24,7 +24,7 @@
     "@std/assert": "jsr:@std/assert@^1",
     "web-tree-sitter": "npm:web-tree-sitter@0.22.6",
     "tree-sitter-typescript": "npm:tree-sitter-typescript@0.23.2",
-    "@hiisi/viola-default-lints": "jsr:@hiisi/viola-default-lints@^0.3.2"
+    "@hiisi/viola-default-lints": "jsr:@hiisi/viola-default-lints@^0.4.0"
   },
   "compilerOptions": {
     "strict": true,

--- a/src/transforms/nodes.ts
+++ b/src/transforms/nodes.ts
@@ -1,8 +1,5 @@
 import type { SyntaxNode } from "@hiisi/viola/grammars";
 
-/** Shorthand, so the signature below reads as one line. */
-type N = SyntaxNode;
-
 /**
  * The tree-sitter node types and field names these transforms match on.
  *
@@ -30,8 +27,8 @@ export const READONLY_KEYWORD = "readonly";
  * the accumulator and the null check.
  */
 export function collectNamed<T>(
-  node: { readonly namedChildren: readonly N[] } | undefined,
-  parse: (child: N) => T | null,
+  node: { readonly namedChildren: readonly SyntaxNode[] } | undefined,
+  parse: (child: SyntaxNode) => T | null,
 ): T[] {
   if (node === undefined) return [];
   const found: T[] = [];


### PR DESCRIPTION
Both viola constraints move to `^0.4.0`, and the version follows.

The default-lints constraint mattered more than it looks. At `^0.3.2` the local
link stopped applying once that package went to 0.4.0, so the gate ran the
published 0.3.2 lints, whose duplicate-strings does not honour `countIn` the way
this config assumes. Seven findings, every one a test literal the config already
meant to exclude.

The `type N = SyntaxNode` shorthand is inlined at its two uses. viola 0.4.0 fixed
type-location to read the project's own config rather than another repo's
layout, so it now correctly sees a one-line alias in a package that has no types
directory and does not want one. Two slightly longer signatures beat configuring
the lint to look away.

0.4.0 rather than 0.3.3 because a consumer on viola 0.3.x cannot take this.

## Sanity

`deno task lint` clean at 25 files. Worth noting the gate only started catching
those seven once the constraint was right, so this package had been checking
itself with the wrong lint pack for a while.